### PR TITLE
Fix: Crash when carousel only has one child.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ export default class Carousel extends Component {
     arrows: React.PropTypes.bool,
     arrowsContainerStyle: Text.propTypes.style,
     arrowstyle: Text.propTypes.style,
-    leftArrowText: React.propTypes.oneOfType([
+    leftArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),
-    rightArrowText: React.propTypes.oneOfType([
+    rightArrowText: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.element,
     ]),
@@ -276,6 +276,7 @@ export default class Carousel extends Component {
       pages.push(children[1]);
     } else if (children.length === 1) {
       pages.push(children[0]);
+    } else if (children.length === 0) {
     } else if (children) {
       pages.push(children);
     } else {


### PR DESCRIPTION
Fix: Crash when carousel only has one child. 
https://github.com/appintheair/react-native-looped-carousel/pull/66

Typo: React.PropTypes typo.